### PR TITLE
resetting whole form instead of the input field of form

### DIFF
--- a/src/components/TaskForm.tsx
+++ b/src/components/TaskForm.tsx
@@ -32,8 +32,7 @@ function TaskForm({setData}:{setData:React.Dispatch<React.SetStateAction<PayLoad
                 prev[formObject['status']].push(task);
                 return {...prev};
             })
-            // formElement.reset();
-            taskRef.current.value='';
+            formElement.reset();
         }
         
     }


### PR DESCRIPTION
Testing Instructions:
1. Create 3 tasks by submitting the task form with valid input and status todo|inprogress|done.
2. each time when the form is submitted a task should be created with given input and shown in the respective category.
3. each time a task gets created the input form and the status select dropdown should be reset to default values, FYI: default value for the input field is empty field, and for the status dropdown is 'todo'.  